### PR TITLE
Add linkchecking to Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _site
 .DS_Store
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
-sudo: required
-language: python
-
-services:
-  - docker
-
+language: ruby
+sudo: false
+cache: bundler
+rvm: 2.3.3
+env:
+  global:
+  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
+install: bundle install
 script:
-  - bash test.sh
+    - bundle exec jekyll build
+    - bundle exec htmlproofer ./_site

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,26 @@
+source "https://rubygems.org"
+ruby RUBY_VERSION
+
+# Hello! This is where you manage which Jekyll version is used to run.
+# When you want to use a different version, change it below, save the
+# file and run `bundle install`. Run Jekyll with `bundle exec`, like so:
+#
+#     bundle exec jekyll serve
+#
+# This will help ensure the proper Jekyll version is running.
+# Happy Jekylling!
+gem "jekyll", "3.4.3"
+
+# If you want to use GitHub Pages, remove the "gem "jekyll"" above and
+# uncomment the line below. To upgrade, run `bundle update github-pages`.
+# gem "github-pages", group: :jekyll_plugins
+
+# If you have any plugins, put them here!
+group :jekyll_plugins do
+   gem "jekyll-feed", "~> 0.6"
+end
+
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem "html-proofer"

--- a/about.html
+++ b/about.html
@@ -10,7 +10,7 @@ title: About
                     <img src="{{ "/img/logos/logo-idr-white.svg" | prepend: site.baseurl }}?{{ site.time | date: '%s%N' }}" alt="IDR logo" class="logo-hero" />
                     <p class="hero-subheader small-10 medium-10 large-10 small-offset-1 medium-offset-1 large-offset-1">Image Data Resource (IDR) is an online, public data repository seeks to store, integrate and serve image datasets from published scientific studies. We have collected and are continuing to receive existing and newly created “reference image" datasets that are valuable resources for a broad community of users, either because they will be frequently accessed and cited or because they can serve as a basis for re-analysis and the development of new computational tools.</p>
                     <br>
-                    <a href="/webclient/userdata/?experimenter=-1" class="large button sites-button">Take a look at the data</a>
+                    <a href="https://idr.openmicroscopy.org/webclient/userdata/?experimenter=-1" class="large button sites-button">Take a look at the data</a>
                 </div>
             </div>
         </header>

--- a/about.html
+++ b/about.html
@@ -34,10 +34,10 @@ title: About
                         used to build the <a href="https://github.com/IDR/infrastructure">infrastructure</a> are maintained
                         and available. A parallel system that enables computational re-analysis of IDR data will be released soon.</p>
 
-                        <p>The IDR includes a <a href="/jupyter">virtual analysis environment</a>
+                        <p>The IDR includes a <a href="https://idr.openmicroscopy.org/jupyter">virtual analysis environment</a>
                         that provides full access to all data. Please contact us for an account.</p>
 
-                        <p>Details on accessing the public IDR API are available under <a href="/about/api.html">about/api.html</a>.
+                        <p>Details on accessing the public IDR API are available under <a href="/api.html">api.html</a>.
                     </div>
                 </div>
             </div>

--- a/api.html
+++ b/api.html
@@ -31,7 +31,7 @@ title: API
                         <p>The code for the IPython notebook below is available on GitHub
                         at <a href="https://github.com/IDR/idr-notebooks/tree/master/notebooks">
                             https://github.com/IDR/idr-notebooks/blob/master/notebooks/IDR_API_example_script.ipynb</a>
-                        as well as on the IDR <a href="/jupyter">virtual analysis environment</a>.
+                        as well as on the IDR <a href="https://idr.openmicroscopy.org/jupyter">virtual analysis environment</a>.
                         </p>
 
                         <hr>

--- a/deployment.html
+++ b/deployment.html
@@ -28,7 +28,7 @@ title: Deployment
             <div class="small-10 small-centered medium-10 medium-centered columns">
                 <div class="row horizontal">
                     <div>
-                        <p>The main <a href="/webclient/userdata/?experimenter=-1">production IDR</a> consists of three servers:</p>
+                        <p>The main <a href="https://idr.openmicroscopy.org/webclient/userdata/?experimenter=-1">production IDR</a> consists of three servers:</p>
                         <ul>
                             <li>Database: A dedicated <a href="https://www.postgresql.org/">PostgreSQL</a> server.</li>
                             <li>OMERO: <a href="https://www.openmicroscopy.org/">OMERO.server and OMERO.web</a> with a highly customised configuration optimised for the data access patterns of the IDR.</li>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@ title: Image Data Resource
                     <h1 class="hero-main-header">Image Data Resource</h1>
                     <h2 class="hero-subheader small-10 medium-10 large-10 small-offset-1 medium-offset-1 large-offset-1">Welcome to the Image Data Resource (IDR). This online, public data repository seeks to store, integrate and serve image datasets from published scientific studies.</h2>
                     <br>
-                    <a href="/webclient/userdata/?experimenter=-1" class="large button sites-button">Take a look at the data</a>
+                    <a href="https://idr.openmicroscopy.org/webclient/userdata/?experimenter=-1" class="large button sites-button">Take a look at the data</a>
                 </div>
             </div>
         </header>
@@ -60,7 +60,7 @@ title: Image Data Resource
             <div class="small-10 small-centered medium-10 medium-centered columns">
                 <div class="row horizontal">
                     <div>
-                        <p><a href="/webclient/?show=well-45407">Datasets in human cells</a>, <a href="/webclient/?show=well-547609">Drosophila</a>, and <a href="/webclient/?show=well-590686">fungi</a> are included. The full <a href="/webclient/?show=well-771034">Mitocheck dataset</a> and a comprehensive <a href="/webclient/?show=plate-4101">chemical screen in human cells</a> are included. Imaging data from <a href="/webclient/?show=plate-4751">Tara Oceans</a>, a global survey of plankton and other marine organisms is also included.</p>
+                        <p><a href="https://idr.openmicroscopy.org/webclient/?show=well-45407">Datasets in human cells</a>, <a href="https://idr.openmicroscopy.org/webclient/?show=well-547609">Drosophila</a>, and <a href="https://idr.openmicroscopy.org/webclient/?show=well-590686">fungi</a> are included. The full <a href="https://idr.openmicroscopy.org/webclient/?show=well-771034">Mitocheck dataset</a> and a comprehensive <a href="https://idr.openmicroscopy.org/webclient/?show=plate-4101">chemical screen in human cells</a> are included. Imaging data from <a href="https://idr.openmicroscopy.org/webclient/?show=plate-4751">Tara Oceans</a>, a global survey of plankton and other marine organisms is also included.</p>
                         <p>Wherever possible, functional annotations (e.g., “increased peripheral actin") and experimental components have been converted to defined terms in the <a href="http://www.ebi.ac.uk/ols/ontologies/efo">EFO</a>, <a href="http://www.ebi.ac.uk/ols/ontologies/cmpo">CMPO</a> or other ontologies, always in collaboration with the data submitters (see example). >80% of the functional annotations have links to defined, published controlled vocabularies.</p>
                     </div> 
                     <div class="row small-up-2 medium-up-4 large-up-4">


### PR DESCRIPTION
This PR partly overlaps with the intent of #17:

- adds a `Gemfile` defining the dependencies
- updates `.travis.yml` to use Ruby containers and run htmlproofer in addition to `jekyll build`

Commits 057bdda and ccdc4ae fix the 12 failures revealed during the `htmlproof` step by:
- prepending the `/webclient and `/jupyter` URL with http://idr.openmicroscopy.org i.e. do not assume the base URL of the deployed site contains the data and the jupyter
- fix `/about/api.html` to use `/api.html`