### PR TITLE
Add IDR version string to footer

### DIFF
--- a/_includes/footer-idr.html
+++ b/_includes/footer-idr.html
@@ -13,7 +13,7 @@
                 </div>
                 <hr class="whitespace">
                 <div class="small-12 columns text-center">
-                    <p class="version-number"><a href="{{ site.baseurl }}/index.html"><img id="version-number" src="{{ "/img/logos/logo-idr.svg" | prepend: site.baseurl }}?{{ site.time | date: '%s%N' }}" alt="IDR logo"></a> version: test123. Last updated: 10 Aug 2017. See <a href="#">release notes.</a></p>
+                    <p class="version-number"><a href="{{ site.baseurl }}/index.html"><img id="version-number" src="{{ "/img/logos/logo-idr.svg" | prepend: site.baseurl }}?{{ site.time | date: '%s%N' }}" alt="IDR logo"></a> version: {{ site.idr_deployment_version }}. Last updated: {{ site.idr_deployment_date }}. See <a href="#">release notes.</a></p>
                 </div>
             </div>
         </div>

--- a/_includes/footer-idr.html
+++ b/_includes/footer-idr.html
@@ -13,7 +13,12 @@
                 </div>
                 <hr class="whitespace">
                 <div class="small-12 columns text-center">
-                    <p class="version-number"><a href="{{ site.baseurl }}/index.html"><img id="version-number" src="{{ "/img/logos/logo-idr.svg" | prepend: site.baseurl }}?{{ site.time | date: '%s%N' }}" alt="IDR logo"></a> version: {{ site.idr_deployment_version }}. Last updated: {{ site.idr_deployment_date }}. See <a href="#">release notes.</a></p>
+                    <p class="version-number"><a href="{{ site.baseurl }}/index.html"><img id="version-number" src="{{ "/img/logos/logo-idr.svg" | prepend: site.baseurl }}?{{ site.time | date: '%s%N' }}" alt="IDR logo"></a>
+                        version: {{ site.idr_deployment_version }}.
+                    {% if site.idr_deployment_date %}
+                        Last updated: {{ site.idr_deployment_date }}.
+                    {% endif %}
+                        See <a href="#">release notes.</a></p>
                 </div>
             </div>
         </div>

--- a/_includes/footer-idr.html
+++ b/_includes/footer-idr.html
@@ -18,7 +18,9 @@
                     {% if site.idr_deployment_date %}
                         Last updated: {{ site.idr_deployment_date }}.
                     {% endif %}
-                        See <a href="#">release notes.</a></p>
+                    {% if site.idr_deployment_notes %}
+                        See <a href="{{ site.idr_deployment_notes }}">release notes.</a></p>
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/_includes/footer-idr.html
+++ b/_includes/footer-idr.html
@@ -11,5 +11,9 @@
                     <p>&copy; 2016-{{ site.time | date: "%Y" }} University of Dundee &amp; Open Microscopy Environment</p>
                     <p>OMERO is distributed under the terms of the GNU GPL. For more information, visit <a href="http://www.openmicroscopy.org">openmicroscopy.org</a></p>
                 </div>
+                <hr class="whitespace">
+                <div class="small-12 columns text-center">
+                    <p class="version-number"><a href="{{ site.baseurl }}/index.html"><img id="version-number" src="{{ "/img/logos/logo-idr.svg" | prepend: site.baseurl }}?{{ site.time | date: '%s%N' }}" alt="IDR logo"></a> version: test123. Last updated: 10 Aug 2017. See <a href="#">release notes.</a></p>
+                </div>
             </div>
         </div>

--- a/css/idr.css
+++ b/css/idr.css
@@ -186,3 +186,12 @@ a {
     border-color: #eceff1 transparent transparent;
 }
 
+#version-number { 
+    margin-right: 5px;
+    width: 50px;
+}
+.version-number {
+    font-size: 11px;
+    font-weight: bold;
+}
+


### PR DESCRIPTION
This adds a version string to the bottom-right corner of the about pages.

<img width="1069" alt="screen shot 2017-08-08 at 16 15 40" src="https://user-images.githubusercontent.com/1644105/29079353-e4a7efe2-7c54-11e7-9178-81d5d1639ed6.png">

Create a config file `idr-version.yml` containing `idr_deployment_version: test123`
Include this in the build: `jekyll build --config idr-version.yml ...`

If no config file is included no version is shown