### PR TITLE
Replace version with a dynamic js lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@
 This repository contains the source code for the IDR Website hosted at
 https://idr.openmicroscopy.org.
 
+## Versioning
+
+This website has multiple version strings.
+- The repository itself uses a [CalVer scheme `YYYY.0M.0D`](https://calver.org/#youtube-dl).
+- The version displayed on the webpages should be the [IDR deployment release](https://github.com/IDR/deployment/), *not* the website release.
+  This is independent of the website release and is not known until deployment time.
+  The IDR version is set to `devel` in this repository, and should be overridden during deployment by creating a file `VERSION` containing the version string.
+
+
 ## Contributing
 
 Please read our [contributing guidelines](/CONTRIBUTING.md) for ways to offer

--- a/_config.yml
+++ b/_config.yml
@@ -2,4 +2,4 @@ url: ''
 repository: IDR/idr.openmicroscopy.org
 baseurl: /idr.openmicroscopy.org
 
-version: 0.5.1
+version: devel

--- a/_includes/foot-idr.html
+++ b/_includes/foot-idr.html
@@ -19,7 +19,7 @@
                 <hr class="whitespace">
                 <div class="small-12 columns text-center">
                     <p class="version-number"><a href="{{ site.baseurl }}/index.html"><img id="version-number" src="{{ "/img/logos/logo-idr.svg" | prepend: site.baseurl }}?{{ site.time | date: '%s%N' }}" alt="IDR logo"></a>
-                        version: {{ site.version }}.
+                        version: <span id="version-number-display">{{ site.version }}</span>.
                     Last updated: {{ site.time | date: "%Y-%m-%d" }}.
                     {% if site.notes %}
                         See <a href="{{ site.notes }}">release notes.</a></p>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -7,3 +7,4 @@
     <script src="{{ "/js/app.js" | prepend: site.baseurl }}?{{ site.time | date: '%s%N' }}"></script>
     <script src="{{ "/js/tool-modal.js" | prepend: site.baseurl }}?{{ site.time | date: '%s%N' }}"></script>
     <script src="{{ "/js/responsive-tables.js" | prepend: site.baseurl }}?{{ site.time | date: '%s%N' }}"></script>
+    <script src="{{ "/js/version.js" | prepend: site.baseurl }}?{{ site.time | date: '%s%N' }}"></script>

--- a/js/version.js
+++ b/js/version.js
@@ -1,0 +1,7 @@
+---
+---
+$(document).ready(function () {
+    $.get('{{ site.baseurl }}/VERSION', null, function(data, textStatus) {
+        $('#version-number-display').text(data);
+    }, 'text');
+});


### PR DESCRIPTION
This ensures the version refers to the idr-environment deployment and not the website version. To enable this a file `VERSION` containing the version string e.g. `test51` should be created in the root of the website after deployment. If this isn't present it'll default to `devel` ~(and you'll get a 404 in your logs)~.

To test this locally: `echo test12345 > VERSION`

Background: IDR#24

Note I've tried to keep this in a vaguely alphabetical order. However since this is added at the end the javascript fails to run due to the itr.js `TOOLS` object error fixed in #32. Iv'e therefore rebased this on top of #32 for now

- [x] --depends-on https://github.com/IDR/idr.openmicroscopy.org/pull/32
- [x] TODO: Add version doc to readme