### PR TITLE
Restore idr deployment version

### DIFF
--- a/_includes/foot-idr.html
+++ b/_includes/foot-idr.html
@@ -19,7 +19,7 @@
                 <hr class="whitespace">
                 <div class="small-12 columns text-center">
                     <p class="version-number"><a href="{{ site.baseurl }}/index.html"><img id="version-number" src="{{ "/img/logos/logo-idr.svg" | prepend: site.baseurl }}?{{ site.time | date: '%s%N' }}" alt="IDR logo"></a>
-                        version: {{ site.data.releases.last["Data release"] }}.
+                        version: {{ site.data.releases.last["Data release"] }}</span>.
                     Last updated: {{ site.time | date: "%Y-%m-%d" }}.
                     {% if site.notes %}
                         See <a href="{{ site.notes }}">release notes.</a></p>

--- a/_includes/foot-idr.html
+++ b/_includes/foot-idr.html
@@ -19,7 +19,7 @@
                 <hr class="whitespace">
                 <div class="small-12 columns text-center">
                     <p class="version-number"><a href="{{ site.baseurl }}/index.html"><img id="version-number" src="{{ "/img/logos/logo-idr.svg" | prepend: site.baseurl }}?{{ site.time | date: '%s%N' }}" alt="IDR logo"></a>
-                        version: {{ site.data.releases.last["Data release"] }}</span>.
+                        version: <span id="version-number-display">{{ site.version }}</span>.
                     Last updated: {{ site.time | date: "%Y-%m-%d" }}.
                     {% if site.notes %}
                         See <a href="{{ site.notes }}">release notes.</a></p>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -7,4 +7,4 @@
     <script src="{{ "/js/app.js" | prepend: site.baseurl }}?{{ site.time | date: '%s%N' }}"></script>
     <script src="{{ "/js/tool-modal.js" | prepend: site.baseurl }}?{{ site.time | date: '%s%N' }}"></script>
     <script src="{{ "/js/responsive-tables.js" | prepend: site.baseurl }}?{{ site.time | date: '%s%N' }}"></script>
-
+    <script src="{{ "/js/version.js" | prepend: site.baseurl }}?{{ site.time | date: '%s%N' }}"></script>

--- a/js/version.js
+++ b/js/version.js
@@ -1,0 +1,7 @@
+---
+---
+$(document).ready(function () {
+    $.get('{{ site.baseurl }}/VERSION', null, function(data, textStatus) {
+        $('#version-number-display').text(data);
+    }, 'text');
+});


### PR DESCRIPTION
The `version:` field in the footer is intended to show the deployment (prodXX, testXX, etc).

This partially reverts https://github.com/IDR/idr.openmicroscopy.org/pull/38 which made it static

See
- https://github.com/IDR/idr.openmicroscopy.org/pull/33
- https://github.com/IDR/deployment/pull/161