### PR TITLE
Update links to curated study repositories

### DIFF
--- a/_includes/aspera.md
+++ b/_includes/aspera.md
@@ -34,7 +34,7 @@ You should now be able to connect to the Aspera server and see the raw data for 
 ## Command-line instructions
 
 The Aspera command line client can be downloaded
-[here](http://www.asperasoft.com/downloads/connect). The following command
+[here](https://downloads.asperasoft.com/en/downloads/2). The following command
 will download all the raw data associated with the `idr0008` submission:
 
     $ ascp -TQ -l40m -P 33001 -i "path/to/asperaweb_id_dsa.openssh" idr0008@fasp.ebi.ac.uk:. /tmp/data/idr0008/

--- a/api.html
+++ b/api.html
@@ -29,8 +29,7 @@ title: API
                 <div class="row horizontal">
                     <div>
                         <p>The code for the IPython notebook below is available on GitHub
-                        at <a href="https://github.com/IDR/idr-notebooks/tree/master/notebooks">
-                            https://github.com/IDR/idr-notebooks/blob/master/notebooks/IDR_API_example_script.ipynb</a>
+                        at <a href="https://github.com/IDR/idr-notebooks/blob/master/IDR_API_example_script.ipynb">IDR_API_example_script.ipynb</a>
                         as well as on the IDR <a href="/jupyter">virtual analysis environment</a>.
                         </p>
 

--- a/build.sh
+++ b/build.sh
@@ -5,4 +5,4 @@ set -e
 set -u
 
 docker run -it --rm -v $PWD:/srv/jekyll -eJEKYLL_UID=$UID jekyll/builder:pages jekyll build --config _config.yml,_prod.yml
-docker run -it --rm -v $PWD/_site:/site jekyll/builder:pages /usr/gem/bin/htmlproofer /site --disable-external --url-swap "/about:" --url-ignore "/jupyter,/webclient/"
+docker run -it --rm -v $PWD/_site:/site jekyll/builder:pages /usr/gem/bin/htmlproofer /site --url-swap "/about:" --url-ignore "/jupyter,/webclient/"

--- a/build.sh
+++ b/build.sh
@@ -5,4 +5,4 @@ set -e
 set -u
 
 docker run -it --rm -v $PWD:/srv/jekyll -eJEKYLL_UID=$UID jekyll/builder:pages jekyll build --config _config.yml,_prod.yml
-docker run -it --rm -v $PWD/_site:/site jekyll/builder:pages /usr/gem/bin/htmlproofer /site --url-swap "/about:" --url-ignore "/jupyter,/webclient/"
+docker run -it --rm -v $PWD/_site:/site/about jekyll/builder:pages /usr/gem/bin/htmlproofer /site --url-ignore "/jupyter,/webclient/"

--- a/experiments.html
+++ b/experiments.html
@@ -198,9 +198,9 @@ title: Experiments
 
                         <p>Examples of non-screen studies include:
                         <ul>
-                            <li><a href="https://github.com/IDR/idr-metadata/tree/master/idr0018-neff-histopathology">
+                            <li><a href="https://github.com/IDR/idr0018-neff-histopathology">
                             idr0018 - histopathology of gene knockouts</a></li>
-                            <li><a href="https://github.com/IDR/idr-metadata/tree/master/idr0021-lawo-pericentriolarmaterial">
+                            <li><a href="https://github.com/IDR/idr0021-lawo-pericentriolarmaterial">
                             idr0021 - protein localization using 3D-SIM  </a></li>
                             <li><a href="https://github.com/IDR/idr-metadata/tree/master/idr0023-szymborska-nuclearpore">
                             idr0023 - protein localization using dSTORM</a></li>

--- a/screens.html
+++ b/screens.html
@@ -203,15 +203,15 @@ title: Screens
                         <ul>
                             <li><a href="https://github.com/IDR/idr-metadata/tree/master/idr0001-graml-sysgro">
                             idr0001 - gene deletion screen</a></li>
-                            <li><a href="https://github.com/IDR/idr-metadata/tree/master/idr0002-heriche-condensation">
+                            <li><a href="https://github.com/IDR/idr0002-heriche-condensation">
                             idr0002 - RNAi screen</a></li>
                             <li><a href="https://github.com/IDR/idr-metadata/tree/master/idr0006-fong-nuclearbodies">
                             idr0006 - protein localization screen</a></li>
                             <li><a href="https://github.com/IDR/idr-metadata/tree/master/idr0009-simpson-secretion">
                             idr0009 - primary and validation RNAi screens</a></li>
-                            <li><a href="https://github.com/IDR/idr-metadata/tree/master/idr0017-breinig-drugscreen">
+                            <li><a href="https://github.com/IDR/idr0017-breinig-drugscreen">
                             idr0017 - small molecule screen</a></li>
-                            <li><a href="https://github.com/IDR/idr-metadata/tree/master/idr0019-sero-nfkappab">
+                            <li><a href="https://github.com/IDR/idr0019-sero-nfkappab">
                             idr0019 - imaging experiment performed in plates but not a screen</a></li>
                         </ul></p>
 

--- a/submission.html
+++ b/submission.html
@@ -212,7 +212,7 @@ title: Submission
                                 remains a reliable way of transferring your data. We will provide you with
                                 shipping details via email.</li>
                                 <li><b>FTP / Aspera</b>: we are working on a link
-                                between IDR and BioStudies (<a href="https://www.ebi.ac.uk/biostudies/submit.html">
+                                between IDR and BioStudies (<a href="https://www.ebi.ac.uk/biostudies/submit">
                                 https://www.ebi.ac.uk/biostudies/submit.html</a>).  If
                                 you can upload your image data to BioStudies via FTP or Aspera, IDR may be able
                                 to access your data directly from there.</li>

--- a/submission.html
+++ b/submission.html
@@ -125,23 +125,23 @@ title: Submission
                         <ul>
                             <li><a href="https://github.com/IDR/idr-metadata/tree/master/idr0001-graml-sysgro">
                             idr0001 - gene deletion screen</a></li>
-                            <li><a href="https://github.com/IDR/idr-metadata/tree/master/idr0002-heriche-condensation">
+                            <li><a href="https://github.com/IDR/idr0002-heriche-condensation">
                             idr0002 - RNAi screen</a></li>
                             <li><a href="https://github.com/IDR/idr-metadata/tree/master/idr0006-fong-nuclearbodies">
                             idr0006 - protein localization screen</a></li>
                             <li><a href="https://github.com/IDR/idr-metadata/tree/master/idr0009-simpson-secretion">
                             idr0009 - primary and validation RNAi screens</a></li>
-                            <li><a href="https://github.com/IDR/idr-metadata/tree/master/idr0017-breinig-drugscreen">
+                            <li><a href="https://github.com/IDR/idr0017-breinig-drugscreen">
                             idr0017 - small molecule screen</a></li>
-                            <li><a href="https://github.com/IDR/idr-metadata/tree/master/idr0019-sero-nfkappab">
+                            <li><a href="https://github.com/IDR/idr0019-sero-nfkappab">
                             idr0019 - imaging experiment performed in plates but not a screen</a></li>
                         </ul></p>
 
                         <p>Example files for non-screen studies can be found here:
                         <ul>
-                            <li><a href="https://github.com/IDR/idr-metadata/tree/master/idr0018-neff-histopathology">
+                            <li><a href="https://github.com/IDR/idr0018-neff-histopathology">
                             idr0018 - histopathology of gene knockouts</a></li>
-                            <li><a href="https://github.com/IDR/idr-metadata/tree/master/idr0021-lawo-pericentriolarmaterial">
+                            <li><a href="https://github.com/IDR/idr0021-lawo-pericentriolarmaterial">
                             idr0021 - protein localization using 3D-SIM  </a></li>
                             <li><a href="https://github.com/IDR/idr-metadata/tree/master/idr0023-szymborska-nuclearpore">
                             idr0023 - protein localization using dSTORM</a></li>


### PR DESCRIPTION
Depends on https://github.com/IDR/idr-metadata/pull/369

This updates the references to the curated metadata repositories in our submission pages to point at the new repositories