### PR TITLE
Prod67 fixes

### DIFF
--- a/api.html
+++ b/api.html
@@ -1,6 +1,8 @@
 ---
 layout: idr
 title: API
+redirect_from:
+  - api/
 ---
 
         <!-- begin marketing header -->

--- a/deployment.html
+++ b/deployment.html
@@ -1,6 +1,8 @@
 ---
 layout: idr
 title: Deployment
+redirect_from:
+  - deployment/
 ---
         <!-- begin marketing header -->
         <header class="marketing-hero">

--- a/download.html
+++ b/download.html
@@ -1,6 +1,8 @@
 ---
 layout: idr
 title: Download
+redirect_from:
+  - download/
 ---
 
         <!-- begin marketing header -->

--- a/experiments.html
+++ b/experiments.html
@@ -1,6 +1,8 @@
 ---
 layout: idr
 title: Experiments
+redirect_from:
+  - experiment/
 ---
         <!-- begin marketing header -->
         <header class="marketing-hero">

--- a/experiments.html
+++ b/experiments.html
@@ -2,7 +2,7 @@
 layout: idr
 title: Experiments
 redirect_from:
-  - experiment/
+  - experiments/
 ---
         <!-- begin marketing header -->
         <header class="marketing-hero">

--- a/index.html
+++ b/index.html
@@ -1,6 +1,8 @@
 ---
 layout: idr
 title: Image Data Resource
+redirect_from:
+  - about.html
 ---
         <!-- begin marketing header -->
         <header class="marketing-hero">

--- a/itr.html
+++ b/itr.html
@@ -1,6 +1,8 @@
 ---
 layout: idr
 title: ITR
+redirect_from:
+  - itr/
 ---
 
 <script>

--- a/mineotaur.html
+++ b/mineotaur.html
@@ -1,6 +1,8 @@
 ---
 layout: idr
 title: Mineotaur
+redirect_from:
+  - mineotaur/
 ---
         <!-- begin marketing header -->
         <header class="marketing-hero">

--- a/screens.html
+++ b/screens.html
@@ -1,6 +1,8 @@
 ---
 layout: idr
 title: Screens
+redirect_from:
+  - screens/
 ---
         <!-- begin marketing header -->
         <header class="marketing-hero">

--- a/submission.html
+++ b/submission.html
@@ -49,8 +49,7 @@ title: Submission
                         </p>
                         <p>To make IDR datasets as widely re-usable as possible,
                         we strongly recommend that submitters make their datasets
-                        available under a <a href="https://creativecommons.org/publicdomain/zero/1.0/">
-                        CC0</a> or <a href="https://creativecommons.org/licenses/by/4.0/">
+                        available under <a href="https://creativecommons.org/licenses/by/4.0/">
                         CC-BY</a> license. The licensing information should
                         be included as part of the metadata .</p>
                         </div>

--- a/submission.html
+++ b/submission.html
@@ -1,6 +1,8 @@
 ---
 layout: idr
 title: Submission
+redirect_from:
+  - submission/
 ---
         <!-- begin marketing header -->
         <header class="marketing-hero">


### PR DESCRIPTION
- update submission page to suggest CC-BY as the recommended license as per our metadata templates
- add redirect for `about.html` page removed in #55 
- add various redirects of form `http://idr.openmicroscopy.org/about/<page>/ -> http://idr.openmicroscopy.org/about/page.html`

The following staging URLs should now be redirecting to an appropriate page:
- https://snoopycrimecop.github.io/idr.openmicroscopy.org/about.html (index page)
- https://snoopycrimecop.github.io/idr.openmicroscopy.org/submission/
- https://snoopycrimecop.github.io/idr.openmicroscopy.org/download/
- https://snoopycrimecop.github.io/idr.openmicroscopy.org/api/
- https://snoopycrimecop.github.io/idr.openmicroscopy.org/deployment/
- https://snoopycrimecop.github.io/idr.openmicroscopy.org/experiments/
- https://snoopycrimecop.github.io/idr.openmicroscopy.org/screens/