### PR TITLE
Gallery link fixes

### DIFF
--- a/_includes/head-idr.html
+++ b/_includes/head-idr.html
@@ -33,12 +33,12 @@
                     <li><a class="logo" href="{{ site.baseurl }}/index.html"><img src="{{ "/img/logos/logo-idr.svg" | prepend: site.baseurl }}?{{ site.time | date: '%s%N' }}" alt="IDR logo"></a></li>
 
                     <li>
-                        <a href="/gallery/cell/">
+                        <a href="/cell/">
                           Cell - IDR
                         </a>
                     </li>
                     <li>
-                        <a href="/gallery/tissue/">
+                        <a href="/tissue/">
                           Tissue - IDR
                         </a>
                     </li>

--- a/_includes/head-idr.html
+++ b/_includes/head-idr.html
@@ -30,7 +30,7 @@
         <div class="main-nav-bar top-bar" id="main-menu">
             <div class="top-bar-left">
                 <ul class="dropdown menu" data-dropdown-menu>
-                    <li><a class="logo" href="{{ site.baseurl }}/index.html"><img src="{{ "/img/logos/logo-idr.svg" | prepend: site.baseurl }}?{{ site.time | date: '%s%N' }}" alt="IDR logo"></a></li>
+                    <li><a class="logo" href="/"><img src="{{ "/img/logos/logo-idr.svg" | prepend: site.baseurl }}?{{ site.time | date: '%s%N' }}" alt="IDR logo"></a></li>
 
                     <li>
                         <a href="/cell/">

--- a/build.sh
+++ b/build.sh
@@ -5,4 +5,4 @@ set -e
 set -u
 
 docker run -it --rm -v $PWD:/srv/jekyll -eJEKYLL_UID=$UID jekyll/builder:pages jekyll build --config _config.yml,_prod.yml
-docker run -it --rm -v $PWD/_site:/site/about jekyll/builder:pages /usr/gem/bin/htmlproofer /site --url-ignore "/jupyter,/webclient/,/cell/,/tissue/"
+docker run -it --rm -v $PWD/_site:/site/about jekyll/builder:pages /usr/gem/bin/htmlproofer /site --url-ignore "/jupyter,/webclient/,/cell/,/tissue/,/,"

--- a/build.sh
+++ b/build.sh
@@ -5,4 +5,4 @@ set -e
 set -u
 
 docker run -it --rm -v $PWD:/srv/jekyll -eJEKYLL_UID=$UID jekyll/builder:pages jekyll build --config _config.yml,_prod.yml
-docker run -it --rm -v $PWD/_site:/site/about jekyll/builder:pages /usr/gem/bin/htmlproofer /site --url-ignore "/jupyter,/webclient/,/gallery/"
+docker run -it --rm -v $PWD/_site:/site/about jekyll/builder:pages /usr/gem/bin/htmlproofer /site --url-ignore "/jupyter,/webclient/,/cell/,/tissue/"

--- a/index.html
+++ b/index.html
@@ -10,7 +10,8 @@ title: Image Data Resource
                     <h1 class="hero-main-header">Image Data Resource</h1>
                     <h2 class="hero-subheader small-10 medium-10 large-10 small-offset-1 medium-offset-1 large-offset-1">Welcome to the Image Data Resource (IDR). This online, public data repository seeks to store, integrate and serve image datasets from published scientific studies.</h2>
                     <br>
-                    <a href="/gallery/" class="large button sites-button">Take a look at the data</a>
+                    <a href="/cell/" class="large button sites-button" style="margin-right: 10px">Cell-IDR</a>
+                    <a href="/tissue/" class="large button sites-button">Tissue-IDR</a>
                 </div>
             </div>
         </header>


### PR DESCRIPTION
Update header links to gallery (without /gallery in the URL).
Also the IDR icon links to home ```/```.
Also update buttons:
![Screen Shot 2019-06-07 at 15 33 35](https://user-images.githubusercontent.com/900055/59111799-ab348d80-8939-11e9-8fc0-23a9fab697f2.png)
