### PR TITLE
Correct capitalization of "OpenStack" in page header.

### DIFF
--- a/deployment.html
+++ b/deployment.html
@@ -9,7 +9,7 @@ redirect_from:
             <div class="row homepage text-center">
 
                 <div class="medium-12 columns">
-                    <h1 class="hero-main-header">Openstack and IDR Ansible Playbooks</h1>
+                    <h1 class="hero-main-header">OpenStack and IDR Ansible Playbooks</h1>
                     <p class="hero-subheader small-10 medium-10 large-10 small-offset-1 medium-offset-1 large-offset-1">
                     The Image Data Resource (IDR) infrastructure is managed using <a href="https://www.ansible.com/">Ansible</a>. This includes provisioning virtual resources on an <a href="https://www.openstack.org/">OpenStack</a> cloud at <a href="https://www.ebi.ac.uk/">EMBL-EBI</a>.
                     </p>


### PR DESCRIPTION
See diff.