### PR TITLE
Add stats paragraph to the top of the studies page

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,7 +155,7 @@ redirect_from:
         </div>
         <!-- end Funding section -->
 
-{% assign releases=site.data.releases %}
+
 
         <!-- begin Current Status section -->
         <hr class="whitespace">
@@ -167,14 +167,7 @@ redirect_from:
             <div class="small-10 small-centered medium-10 medium-centered columns">
                 <div class="row horizontal">
                     <div>
-                        <p>Currently, the IDR (version {{ releases.last["Code version"] }}, released on
-                        {{ releases.last.Date }}) contains {{ releases.last["Size (TB)"] | round }} Tb of
-                        multi-dimensional image data consisting of {{ releases.last.Planes | divided_by: 1000000 }} millions of
-                        individual 2D planes. IDR contains over a million different experiments.
-                        Data comes from studies on human, Drosophila, budding and fission yeast,
-                        and mouse cells and tissue. Imaging modalities represented so far include
-                        high content screens, time-lapse imaging, whole slide histopathology,
-                        and super-resolution microscopy. See <a href="studies.html">the full list
+                        <p>See <a href="studies.html">the full list
                         of published studies</a> for more details.</p>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@ redirect_from:
                         <a href="https://cordis.europa.eu/project/rcn/198649_en.html">653493</a>
                         (<a href="https://globalbioimaging.org/">Global BioImaging</a> Project) and
                         <a href="https://www.cordis.europa.eu/project/rcn/197885_en.html">654248</a>
-                        (<a href="https://www.corbel-project.eu/home.html">CORBEL</a>). For 2018-2021, dataset
+                        (<a href="https://www.corbel-project.eu/home.html">CORBEL</a>). For 2018-2022, dataset
                         submission and publication is funded by the Wellcome Trust (Ref: 212962/Z/18/Z)
                         and integration with EMBL-EBI's BioStudies and other resources is funded by the
                         BBSRC (Ref: <a href="https://bbsrc.ukri.org/research/grants/grants/AwardDetails.aspx?FundingReference=BB/R015384/1">BB/R015384/1</a>).

--- a/studies.html
+++ b/studies.html
@@ -18,6 +18,35 @@ redirect_from:
 </header>
 <!-- end marketing header -->
 
+{% assign releases=site.data.releases %}
+{% assign sorted_studies = site.data.studies | sort: 'Study' %}
+{% assign unique_studies = site.data.studies | map: 'Study' | uniq %}
+
+<!-- begin Current Status section -->
+<hr class="whitespace">
+<div class="row column text-center">
+    <h2>Current Status</h2>
+</div>
+<hr>
+<div class="row">
+    <div class="small-10 small-centered medium-10 medium-centered columns">
+        <div class="row horizontal">
+            <div>
+<p>Currently, the IDR (version {{ releases.last["Code version"] }}, released on
+
+{{ releases.last.Date }}) contains {{ releases.last["Size (TB)"] | round }} TB
+of multi-dimensional images consisting of
+{{ releases.last.Images | divided_by: 1000000 }} millions of multi-dimensional
+images or {{ releases.last.Planes | divided_by: 1000000 }} millions of
+individual 2D planes. IDR contains over a million different experiments.
+Data comes from {{ unique_studies | size }} studies on human, Drosophila,
+budding and fission yeast, and mouse cells and tissue. Imaging modalities represented so far include high content screens, time-lapse imaging, whole slide histopathology, and super-resolution microscopy.
+The resource receives over 2500 unique visits per week.</p>
+            </div>
+        </div>
+    </div>
+</div>
+
     <hr class="whitespace">
     <div class="row column text-center">
         <h2>Studies</h2>
@@ -36,7 +65,6 @@ redirect_from:
         <th>Average dimensions (XYZCT)</th>
     </thead>
     <tbody>
-    {% assign sorted_studies = site.data.studies | sort: 'Study' %}
     {% for row in sorted_studies %}
       {% if row.Container == "landing page" %}
         {% continue %}

--- a/studies.html
+++ b/studies.html
@@ -34,14 +34,15 @@ redirect_from:
             <div>
 <p>Currently, the IDR (version {{ releases.last["Code version"] }}, released on
 
-{{ releases.last.Date }}) contains {{ releases.last["Size (TB)"] | round }} TB
+{{ releases.last.Date }}) contains
+<b>{{ releases.last["Size (TB)"] | round }}</b> TB
 of multi-dimensional images consisting of
-{{ releases.last.Images | divided_by: 1000000 }} millions of multi-dimensional
-images or {{ releases.last.Planes | divided_by: 1000000 }} millions of
-individual 2D planes. IDR contains over a million different experiments.
-Data comes from {{ unique_studies | size }} studies on human, Drosophila,
+<b>{{ releases.last.Images | divided_by: 1000000 }} M</b> multi-dimensional 
+images or
+<b>{{ releases.last.Planes | divided_by: 1000000 }} M</b> individual 2D planes. IDR contains <b> 1 M</b> different experiments.
+Data comes from <b>{{ unique_studies | size }}</b> studies on human, Drosophila,
 budding and fission yeast, and mouse cells and tissue. Imaging modalities represented so far include high content screens, time-lapse imaging, whole slide histopathology, and super-resolution microscopy.
-The resource receives over 2500 unique visits per week.</p>
+The resource receives over <b>2500</b> unique visits per week.</p>
             </div>
         </div>
     </div>

--- a/studies.html
+++ b/studies.html
@@ -35,11 +35,11 @@ redirect_from:
 <p>Currently, the IDR (version {{ releases.last["Code version"] }}, released on
 
 {{ releases.last.Date }}) contains
-<b>{{ releases.last["Size (TB)"] | round }}</b> TB
+<b>{{ releases.last["Size (TB)"] | round }} TB</b>
 of multi-dimensional images consisting of
 <b>{{ releases.last.Images | divided_by: 1000000 }} M</b> multi-dimensional 
 images or
-<b>{{ releases.last.Planes | divided_by: 1000000 }} M</b> individual 2D planes. IDR contains <b> 1 M</b> different experiments.
+<b>{{ releases.last.Planes | divided_by: 1000000 }} M</b> individual 2D planes. IDR contains over <b>1 M</b> different experiments.
 Data comes from <b>{{ unique_studies | size }}</b> studies on human, Drosophila,
 budding and fission yeast, and mouse cells and tissue. Imaging modalities represented so far include high content screens, time-lapse imaging, whole slide histopathology, and super-resolution microscopy.
 The resource receives over <b>2500</b> unique visits per week.</p>

--- a/studies.html
+++ b/studies.html
@@ -10,7 +10,7 @@ redirect_from:
 
         <div class="medium-12 columns">
             <img src="{{ "/img/logos/logo-idr-white.svg" | prepend: site.baseurl }}?{{ site.time | date: '%s%N' }}" alt="IDR logo" class="logo-hero" />
-            <p class="hero-subheader small-10 medium-10 large-10 small-offset-1 medium-offset-1 large-offset-1">Image Data Resource (IDR) is an online, public data repository which seeks to store, integrate and serve image datasets from published scientific studies. We have collected and are continuing to receive existing and newly created “reference image" datasets that are valuable resources for a broad community of users, either because they will be frequently accessed and cited or because they can serve as a basis for re-analysis and the development of new computational tools.</p>
+            <p class="hero-subheader small-10 medium-10 large-10 small-offset-1 medium-offset-1 large-offset-1">The Image Data Resource (IDR) is an online, public data repository which seeks to store, integrate and serve image datasets from published scientific studies. We have collected and are continuing to receive existing and newly created “reference image" datasets that are valuable resources for a broad community of users, either because they will be frequently accessed and cited or because they can serve as a basis for re-analysis and the development of new computational tools.</p>
             <br>
             <a href="/webclient/userdata/?experimenter=-1" class="large button sites-button">Take a look at the data</a>
         </div>

--- a/studies.html
+++ b/studies.html
@@ -10,7 +10,7 @@ redirect_from:
 
         <div class="medium-12 columns">
             <img src="{{ "/img/logos/logo-idr-white.svg" | prepend: site.baseurl }}?{{ site.time | date: '%s%N' }}" alt="IDR logo" class="logo-hero" />
-            <p class="hero-subheader small-10 medium-10 large-10 small-offset-1 medium-offset-1 large-offset-1">Image Data Resource (IDR) is an online, public data repository seeks to store, integrate and serve image datasets from published scientific studies. We have collected and are continuing to receive existing and newly created “reference image" datasets that are valuable resources for a broad community of users, either because they will be frequently accessed and cited or because they can serve as a basis for re-analysis and the development of new computational tools.</p>
+            <p class="hero-subheader small-10 medium-10 large-10 small-offset-1 medium-offset-1 large-offset-1">Image Data Resource (IDR) is an online, public data repository which seeks to store, integrate and serve image datasets from published scientific studies. We have collected and are continuing to receive existing and newly created “reference image" datasets that are valuable resources for a broad community of users, either because they will be frequently accessed and cited or because they can serve as a basis for re-analysis and the development of new computational tools.</p>
             <br>
             <a href="/webclient/userdata/?experimenter=-1" class="large button sites-button">Take a look at the data</a>
         </div>


### PR DESCRIPTION
The `Current Status` paragraph which contains essential stats about the IDR is quite hidden at the bottom of the index page. This PR proposes to move it to the top of the page listing the published studies (and their stats). It also includes commonly used IDR statistics including:

- the total number of 5D images
- the total number of unique studies
- the average number of unique visitors

Feedback on the best place to put this information as well as additional/alternative valuable metrics welcome.