### PR TITLE
Add note about aspera version

### DIFF
--- a/_includes/aspera.md
+++ b/_includes/aspera.md
@@ -12,7 +12,7 @@ accession number e.g. `idr0001`.
 
 ## Desktop client
 
-Download and install the [Aspera desktop client](https://downloads.asperasoft.com/en/downloads/2).
+Download and install the [Aspera desktop client](https://downloads.asperasoft.com/en/downloads/2) version 3.9.6 (newer versions won't work yet).
 
 You must also download and configure the [Aspera public key `asperaweb_id_dsa.openssh`](img/aspera/asperaweb_id_dsa.openssh) to connect to the server.
 


### PR DESCRIPTION
Add note that later versions than 3.9.6 of the aspera desktop client won't work yet, until EBI upgraded the server.