### PR TITLE
replace docker cmd as per www.op..py.org

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -1,1 +1,1 @@
-docker run -it --rm -p 4000:4000 -v $PWD:/src jekyll/jekyll jekyll server -w -s /src
+docker run -it --rm -p 4000:4000 -v $PWD:/srv/jekyll jekyll/builder:pages jekyll server -w


### PR DESCRIPTION
When working on this repo, noticed that the command from ``docker.sh`` file is failing for me locally with

<details>

```
docker run -it --rm -p 4000:4000 -v $PWD:/src jekyll/jekyll jekyll server -w -s /src
Unable to find image 'jekyll/jekyll:latest' locally
latest: Pulling from jekyll/jekyll
df9b9388f04a: Pull complete 
837e9cfc7e43: Pull complete 
c7850f1a8c23: Pull complete 
6ca4c39baa3d: Pull complete 
daa3a8cb79d3: Pull complete 
b2ded23c9638: Pull complete 
Digest: sha256:d5ce76846e2c4e037040d093954aae4441eb45e2e2ae4ff84cd7aeca6e694b28
Status: Downloaded newer image for jekyll/jekyll:latest
ruby 3.1.1p18 (2022-02-18 revision 53f5fc4236) [x86_64-linux-musl]
Configuration file: /src/_config.yml
            Source: /src
       Destination: /srv/jekyll/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
                    done in 1.384 seconds.
 Auto-regeneration: enabled for '/src'
                    ------------------------------------------------
      Jekyll 4.2.2   Please append `--trace` to the `serve` command 
                     for any additional information or backtrace. 
                    ------------------------------------------------
<internal:/usr/local/lib/ruby/site_ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require': cannot load such file -- webrick (LoadError)
	from <internal:/usr/local/lib/ruby/site_ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from /usr/gem/gems/jekyll-4.2.2/lib/jekyll/commands/serve/servlet.rb:3:in `<top (required)>'
	from /usr/gem/gems/jekyll-4.2.2/lib/jekyll/commands/serve.rb:179:in `require_relative'
	from /usr/gem/gems/jekyll-4.2.2/lib/jekyll/commands/serve.rb:179:in `setup'
	from /usr/gem/gems/jekyll-4.2.2/lib/jekyll/commands/serve.rb:100:in `process'
	from /usr/gem/gems/jekyll-4.2.2/lib/jekyll/command.rb:91:in `block in process_with_graceful_fail'
	from /usr/gem/gems/jekyll-4.2.2/lib/jekyll/command.rb:91:in `each'
	from /usr/gem/gems/jekyll-4.2.2/lib/jekyll/command.rb:91:in `process_with_graceful_fail'
	from /usr/gem/gems/jekyll-4.2.2/lib/jekyll/commands/serve.rb:86:in `block (2 levels) in init_with_program'
	from /usr/gem/gems/mercenary-0.4.0/lib/mercenary/command.rb:221:in `block in execute'
	from /usr/gem/gems/mercenary-0.4.0/lib/mercenary/command.rb:221:in `each'
	from /usr/gem/gems/mercenary-0.4.0/lib/mercenary/command.rb:221:in `execute'
	from /usr/gem/gems/mercenary-0.4.0/lib/mercenary/program.rb:44:in `go'
	from /usr/gem/gems/mercenary-0.4.0/lib/mercenary.rb:21:in `program'
	from /usr/gem/gems/jekyll-4.2.2/exe/jekyll:15:in `<top (required)>'
	from /usr/gem/bin/jekyll:25:in `load'
	from /usr/gem/bin/jekyll:25:in `<main>'
```

</details>

When replaced as suggested in this PR, the docker command is working for me.

cc @sbesson @joshmoore 
