### PR TITLE
Fix typo in data download instructions.

### DIFF
--- a/_includes/filezilla.md
+++ b/_includes/filezilla.md
@@ -1,6 +1,6 @@
 ## General instructions
 
-The raw data of all studies published in IDR can be downloaded using using anonymous File Transfer Protocol (FTP). We recommend using the [FileZilla client](https://filezilla-project.org/download.php).
+The raw data of all studies published in IDR can be downloaded using anonymous File Transfer Protocol (FTP). We recommend using the [FileZilla client](https://filezilla-project.org/download.php).
 
 You can download both whole studies as well as parts/single images.
 


### PR DESCRIPTION
Dear community,

Last year (Jul 19, 2023), I was able to download image data from the IDR after I reached out to the authors of the corresponding publication and they pointed me to this page: https://idr.openmicroscopy.org/about/download.html Many thanks to my former Outreachy intern @ana42742 who greatly assisted in the process!

Today, I would like to download more data, using a cluster rather than my laptop. So I went back to the 'Data download' instructions and noticed that the page had changed (indeed, the bottom of the page says 'IDR logo: prod120. Last updated: 2024-03-06').

I can browse the Git history to find the old instructions with the Aspera CLI client, but I'd be curious to know why you decided to 'migrate from Aspera to FileZilla' (since I can't access the document referenced in #189). Usually, when working with large datasets, we use HPC clusters and, hence, prefer CLI over GUI tools.

Cc'ing @joshmoore here.

Best,
Marianne