### PR TITLE
Explain that in ftp you have to use binary

### DIFF
--- a/_includes/filezilla.md
+++ b/_includes/filezilla.md
@@ -53,7 +53,13 @@ Or a single one, e.g.:
 
     ftp> ls idr0044-*
 
-Use the `get` command to download a specific file, and `bye` to close the connection.
+Change the mode to `binary`
+
+    ftp> binary
+
+Use the `get` command to download a specific file.
+
+    ftp> get "path-to-file-in-ftp-server" "path-to-local-file"
 
 ### Desktop client step-by-step
 


### PR DESCRIPTION
cc @dominikl - as discussed, adding the explanation about the ``binary`` in the ftp workflow.

Btw, what is the reason that we recommend Globus ? The instructions clearly say "you have to create an account to download". Seems much more complex than FileZilla or ftp.

cc @sbesson 