### PR TITLE
Ignore www.dundee.ac.uk

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,4 +5,4 @@ set -e
 set -u
 
 docker run --rm -v $PWD:/srv/jekyll -eJEKYLL_UID=$UID jekyll/builder:pages jekyll build --config _config.yml,_prod.yml
-docker run --rm -v $PWD/_site:/site/about jekyll/builder:pages /usr/gem/bin/htmlproofer /site --ignore-urls "/jupyter/,/filezilla-project.org/,/webclient/,/cell/,/tissue/,/login.binder.bioimagearchive.org/,/biii.eu/,/ncbi.nlm.nih.gov/,/localhost/,/github.com/" --only_4xx --no-enforce-https --allow-missing-href --ignore-status-codes "400,404"
+docker run --rm -v $PWD/_site:/site/about jekyll/builder:pages /usr/gem/bin/htmlproofer /site --ignore-urls "/jupyter/,/filezilla-project.org/,/webclient/,/cell/,/tissue/,/login.binder.bioimagearchive.org/,/biii.eu/,/ncbi.nlm.nih.gov/,/localhost/,/github.com/,/www.dundee.ac.uk/" --only_4xx --no-enforce-https --allow-missing-href --ignore-status-codes "400,404"


### PR DESCRIPTION
to fix the build. 

The www.dundee.ac.uk url is persistently reporting 403.

The link is okay, but most probably the combination of the htmlproofer used in this repo and the policy on the uod website is not compatible.

cc @dominikl 