### PR TITLE
Simplify analysis-environments.html to refer to idr-notebooks repo

### DIFF
--- a/analysis-environments.html
+++ b/analysis-environments.html
@@ -12,7 +12,7 @@ redirect_from:
                 <div class="medium-12 columns">
                     <h1 class="hero-main-header">IDR and Analysis</h1>
                     <p class="hero-subheader small-10 medium-10 large-10 small-offset-1 medium-offset-1 large-offset-1">
-                     <p>The Image Data Resource (IDR) uses Analysis Environments provided and maintained by third parties.
+                     <p>Guides on how to access Image metadata and pixel data from IDR for analysis.
                      </p>
                 </div>
             </div>
@@ -21,7 +21,7 @@ redirect_from:
         <!-- begin Background section -->
         <hr class="whitespace">
         <div class="row column text-center">
-            <h2>Environments</h2>
+            <h2>IDR access via the OMERO API</h2>
         </div>
         <hr>
         <div class="row">
@@ -29,43 +29,13 @@ redirect_from:
                 <div class="row horizontal">
                     <div>
                         <p>
-                        We have a set of notebooks and apps that can be run in several
-                        environments managed by third party. IDR mainly uses <a href="https://binderhub.readthedocs.io/en/latest/">BinderHub</a>.
-                        The notebooks can be run by anyone without a login. They are available to anyone interested in exploring and mining the diverse and vast range of image data and metadata in the IDR. All notebook sessions are subject to available resources, are limited by the network resources they can access, and will automatically terminate after a period of inactivity. You should consider the notebook environments as suitable for temporary storage only.
-                        Below is a list of environments currently supported.
+                        The IDR is based on the OMERO platform, which provides an open API for accessing image metadata and pixel data.
                        </p>
-                        <ul>
-                            <li>The public BinderHub <a href="https://mybinder.org">mybinder.org</a></li>
-                            <li>A dedicated BinderHub <a href="https://binder.bioimagearchive.org">binder.bioimagearchive.org</a> hosted <a href="https://www.ebi.ac.uk/">EMBL-EBI</a></li>
-                            <li>Some notebooks can be run in <a href="https://colab.research.google.com/">Google Colab</a></li>
-                        </ul>
+                       <p>
+                        Please see the <a href="https://github.com/IDR/idr-notebooks/" target="_blank">idr-notebooks</a> repository
+                        for example notebooks that demonstrate how to access IDR data via the OMERO API.
+                       </p>
                     </div>
-                </div>
-            </div>
-        </div>
-
-
-       <hr class="whitespace">
-        <div class="row column text-center">
-            <h2>Developing your own set of notebooks</h2>
-        </div>
-        <div class="row">
-            <div class="small-10 small-centered medium-10 medium-centered columns">
-                <div class="row horizontal">
-                    <div>
-                      <p>
-                        If you are interested in developing your own data analysis notebooks on our analysis platform please contact us with your GitHub username.
-                        This will give you more computational resources including scratch storage space than is available through the public access.
-                      </p>
-                      <p>
-                        We will do our best to maintain this scratch space across upgrades, though in the event of unforeseen issues we may need to delete all scratch space, and you should consider it as suitable for temporary storage only.
-                        Your scratch space may be deleted without warning if you have not logged in for over a month.
-                      </p>
-                      <div class="row column text-center">
-                        <a href="https://login.binder.bioimagearchive.org/" class="large button sites-button">Login with GitHub</a>
-                      </div>
-                    </div>
-
                 </div>
             </div>
         </div>

--- a/analysis-environments.html
+++ b/analysis-environments.html
@@ -29,10 +29,7 @@ redirect_from:
                 <div class="row horizontal">
                     <div>
                         <p>
-                        The IDR is based on the OMERO platform, which provides an open API for accessing image metadata and pixel data.
-                       </p>
-                       <p>
-                        Please see the <a href="https://github.com/IDR/idr-notebooks/" target="_blank">idr-notebooks</a> repository
+                        The IDR is based on the OMERO platform, which provides an open API for accessing image metadata and pixel data. Please see the README of the <a href="https://github.com/IDR/idr-notebooks/" target="_blank">idr-notebooks</a> repository
                         for example notebooks that demonstrate how to access IDR data via the OMERO API.
                        </p>
                     </div>


### PR DESCRIPTION
Update the https://idr.openmicroscopy.org/about/analysis-environments.html page to remove out of date info and refer to idr-notebooks repo.

The page isn't really about "analysis environments" any more, but I don't think it's worth creating a new page and redirecting etc.